### PR TITLE
Update MACAddress variable for XLE

### DIFF
--- a/src/rdkb/impl.c
+++ b/src/rdkb/impl.c
@@ -43,7 +43,7 @@
 #define PARTNER_ID				"Device.DeviceInfo.X_RDKCENTRAL-COM_Syndication.PartnerId"
 #define ACCOUNT_ID				"Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.AccountInfo.AccountID"
 #define FIRMW_START_TIME			"Device.DeviceInfo.X_RDKCENTRAL-COM_MaintenanceWindow.FirmwareUpgradeStartTime"
-#define FIRMW_END_TIME			"Device.DeviceInfo.X_RDKCENTRAL-COM_MaintenanceWindow.FirmwareUpgradeEndTime" 
+#define FIRMW_END_TIME			        "Device.DeviceInfo.X_RDKCENTRAL-COM_MaintenanceWindow.FirmwareUpgradeEndTime" 
 
 #if defined(_COSA_BCM_MIPS_)
 #define DEVICE_MAC                   "Device.DPoE.Mac_address"
@@ -52,6 +52,8 @@
 #elif defined(RDKB_EMU)
 #define DEVICE_MAC                   "Device.DeviceInfo.X_COMCAST-COM_WAN_MAC"
 #elif defined(_HUB4_PRODUCT_REQ_)
+#define DEVICE_MAC                   "Device.DeviceInfo.X_COMCAST-COM_WAN_MAC"
+#elif defined(_WNXL11BWL_PRODUCT_REQ_)
 #define DEVICE_MAC                   "Device.DeviceInfo.X_COMCAST-COM_WAN_MAC"
 #else
 #define DEVICE_MAC                   "Device.X_CISCO_COM_CableModem.MACAddress"

--- a/src/rdkb/impl.c
+++ b/src/rdkb/impl.c
@@ -53,7 +53,7 @@
 #define DEVICE_MAC                   "Device.DeviceInfo.X_COMCAST-COM_WAN_MAC"
 #elif defined(_HUB4_PRODUCT_REQ_)
 #define DEVICE_MAC                   "Device.DeviceInfo.X_COMCAST-COM_WAN_MAC"
-#elif defined(_WNXL11BWL_PRODUCT_REQ_)
+#elif defined(RDKB_EXTENDER)
 #define DEVICE_MAC                   "Device.DeviceInfo.X_COMCAST-COM_WAN_MAC"
 #else
 #define DEVICE_MAC                   "Device.X_CISCO_COM_CableModem.MACAddress"

--- a/src/rdkb/impl.c
+++ b/src/rdkb/impl.c
@@ -53,7 +53,7 @@
 #define DEVICE_MAC                   "Device.DeviceInfo.X_COMCAST-COM_WAN_MAC"
 #elif defined(_HUB4_PRODUCT_REQ_)
 #define DEVICE_MAC                   "Device.DeviceInfo.X_COMCAST-COM_WAN_MAC"
-#elif defined(RDKB_EXTENDER)
+#elif defined(_WNXL11BWL_PRODUCT_REQ_)
 #define DEVICE_MAC                   "Device.DeviceInfo.X_COMCAST-COM_WAN_MAC"
 #else
 #define DEVICE_MAC                   "Device.X_CISCO_COM_CableModem.MACAddress"


### PR DESCRIPTION
LTE-457, LTE-330 , - webconfig 403 failure due to NULL serialNumber

XLE devices don't have CcspCMAgent, (XLE devices support only extender mode or LTE mode).  So Need to remove the CMAgent dependency for getting MACaddress, instead use the Device.DeviceInfo.X_COMCAST-COM_WAN_MAC for obtaining the MAC address.

Error 
220725-20:47:20.288292 [mod=WEBCONFIG, lvl=ERROR] [tid=2012] WEBCONFIG: Failed to GetValue for Device.X_CISCO_COM_CableModem.MACAddress