### PR TITLE
Resolving Components Dependency of rdkcentral RBUS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,7 +43,6 @@ include_directories(${INCLUDE_DIR}
                     ${INCLUDE_DIR}/cjson
                     ${INCLUDE_DIR}/msgpack
                     ${INCLUDE_DIR}/rbus
-		    ${INCLUDE_DIR}/rbus-core
 		    ${INCLUDE_DIR}/rtmessage
 		    ${INCLUDE_DIR}/wdmp-c
 		    ${INCLUDE_DIR}/cimplog
@@ -103,43 +102,19 @@ ExternalProject_Add(wdmp-c
 add_library(libwdmp-c STATIC SHARED IMPORTED)
 add_dependencies(libwdmp-c wdmp-c)
 
-# rtMessage external dependency
-#-------------------------------------------------------------------------------
-ExternalProject_Add(rtMessage
-     PREFIX ${CMAKE_CURRENT_BINARY_DIR}/_prefix/rtMessage
-     GIT_REPOSITORY https://github.com/rdkcmf/rdk-rtmessage.git
-     GIT_TAG rdk-next
-     CMAKE_ARGS += -DBUILD_RTMESSAGE_LIB=ON
-                   -DBUILD_RTMESSAGE_SAMPLE_APP=ON
-                   -DBUILD_FOR_DESKTOP=ON
-                   -DBUILD_DATAPROVIDER_LIB=ON
-                   -DCMAKE_INSTALL_PREFIX=${INSTALL_DIR} -DBUILD_TESTING=OFF
-)
-add_library(librtMessage STATIC SHARED IMPORTED)
-add_dependencies(librtMessage rtMessage)
-
-# rbus-core external dependency	
-#-------------------------------------------------------------------------------
-ExternalProject_Add(rbus-core
-     DEPENDS rtMessage
-     PREFIX ${CMAKE_CURRENT_BINARY_DIR}/_prefix/rbus-core
-     GIT_REPOSITORY https://github.com/rdkcmf/rbuscore.git
-     GIT_TAG rdk-next
-     CMAKE_ARGS += DBUILD_FOR_DESKTOP=ON -DCMAKE_INSTALL_PREFIX=${INSTALL_DIR}
-                   -DBUILD_TESTING=OFF
-)
-add_library(librbus-core STATIC SHARED IMPORTED)
-add_dependencies(librbus-core rbus-core)
-
 # rbus external dependency
 #-------------------------------------------------------------------------------
 ExternalProject_Add(rbus
-     DEPENDS rtMessage rbus-core
      PREFIX ${CMAKE_CURRENT_BINARY_DIR}/_prefix/rbus
-     GIT_REPOSITORY https://github.com/rdkcmf/rbus.git
-     GIT_TAG rdk-next
+     GIT_REPOSITORY https://github.com/rdkcentral/rbus.git
+     GIT_TAG main
      CMAKE_ARGS += -DBUILD_FOR_DESKTOP=ON -DCMAKE_INSTALL_PREFIX=${INSTALL_DIR} -DBUILD_TESTING=OFF
 )
+add_library(librbuscore STATIC SHARED IMPORTED)
+add_dependencies(librbuscore rbuscore)
+
+add_library(librtMessage STATIC SHARED IMPORTED)
+add_dependencies(librtMessage rtMessage)
 
 add_library(librbus STATIC SHARED IMPORTED)
 add_dependencies(librbus rbus)

--- a/include/cpeabs.h
+++ b/include/cpeabs.h
@@ -21,12 +21,6 @@
 
 #if ! defined(DEVICE_EXTENDER)
 #include <cimplog.h>
-#include <rbus/rbus.h>
-#include <rbus/rbus_object.h>
-#include <rbus/rbus_property.h>
-#include <rbus/rbus_value.h>
-#include <rbus-core/rbus_core.h>
-#include <rbus-core/rbus_session_mgr.h>
 #endif
 
 /*----------------------------------------------------------------------------*/

--- a/include/cpeabs.h
+++ b/include/cpeabs.h
@@ -21,6 +21,7 @@
 
 #if ! defined(DEVICE_EXTENDER)
 #include <cimplog.h>
+#include <rbus/rbus.h>
 #endif
 
 /*----------------------------------------------------------------------------*/

--- a/src/rdkb/impl.c
+++ b/src/rdkb/impl.c
@@ -21,11 +21,6 @@
 #include <fcntl.h>
 #include <errno.h>
 #include <rbus/rbus.h>
-#include <rbus/rbus_object.h>
-#include <rbus/rbus_property.h>
-#include <rbus/rbus_value.h>
-#include <rbus-core/rbus_core.h>
-#include <rbus-core/rbus_session_mgr.h>
 #include "cpeabs.h"
 /*----------------------------------------------------------------------------*/
 /*                                   Macros                                   */

--- a/src/rdkc/impl.c
+++ b/src/rdkc/impl.c
@@ -21,11 +21,6 @@
 #include <fcntl.h>
 #include <errno.h>
 #include <rbus/rbus.h>
-#include <rbus/rbus_object.h>
-#include <rbus/rbus_property.h>
-#include <rbus/rbus_value.h>
-#include <rbus-core/rbus_core.h>
-#include <rbus-core/rbus_session_mgr.h>
 #include <stdio.h>
 #include <sys/sysinfo.h>
 #include <cjson/cJSON.h>

--- a/src/rdkv/impl.c
+++ b/src/rdkv/impl.c
@@ -20,12 +20,9 @@
 #include <ctype.h>
 #include <fcntl.h>
 #include <errno.h>
-#include <rbus/rbus.h>
 #include <rbus/rbus_object.h>
 #include <rbus/rbus_property.h>
 #include <rbus/rbus_value.h>
-#include <rbus-core/rbus_core.h>
-#include <rbus-core/rbus_session_mgr.h>
 #include <stdio.h>
 #include <sys/sysinfo.h>
 #include <cjson/cJSON.h>

--- a/src/rdkv/impl.c
+++ b/src/rdkv/impl.c
@@ -20,9 +20,7 @@
 #include <ctype.h>
 #include <fcntl.h>
 #include <errno.h>
-#include <rbus/rbus_object.h>
-#include <rbus/rbus_property.h>
-#include <rbus/rbus_value.h>
+#include <rbus/rbus.h>
 #include <stdio.h>
 #include <sys/sysinfo.h>
 #include <cjson/cJSON.h>

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -46,7 +46,7 @@ set(SOURCES test_rdkb.c ${PROJECT_SOURCE_DIR}/src/rdkb/impl.c )
 
 add_executable(test_rdkb ${SOURCES})
 
-target_link_libraries (test_rdkb -lcjson -lcunit -lmsgpackc -lwdmp-c -lcimplog -lpthread -lrbus -lrbus-core)
+target_link_libraries (test_rdkb -lcjson -lcunit -lmsgpackc -lwdmp-c -lcimplog -lpthread -lrbus)
 
 target_link_libraries (test_rdkb gcov -Wl,--no-as-needed )
 
@@ -61,7 +61,7 @@ set(SOURCES test_rdkv.c ${PROJECT_SOURCE_DIR}/src/rdkv/impl.c )
 
 add_executable(test_rdkv ${SOURCES})
 
-target_link_libraries (test_rdkv -lcjson -lcunit -lmsgpackc -lwdmp-c -lcimplog -lpthread -lrbus -lrbus-core)
+target_link_libraries (test_rdkv -lcjson -lcunit -lmsgpackc -lwdmp-c -lcimplog -lpthread -lrbus)
 
 target_link_libraries (test_rdkv gcov -Wl,--no-as-needed )
 


### PR DESCRIPTION
RDKB-45117: RDKB-Resolving Components Dependency of rdkcentral RBUS
Reason for change: Using Federated Rbus from RDKCentral github
Test Procedure: Build all platforms
Risks: Low
Priority: P1
Signed-off-by: Netaji Panigrahi <Netaji_Panigrahi@comcast.com>