### PR TITLE
Added Support to return WAN MAC for RDKV devices

### DIFF
--- a/src/rdkv/impl.c
+++ b/src/rdkv/impl.c
@@ -186,8 +186,7 @@ char* get_deviceMAC()
 
 char* get_deviceWanMAC()
 {
-	//TODO:return the wan mac value
-	return NULL;
+	return get_deviceMAC();
 }
 
 char * getSerialNumber()


### PR DESCRIPTION
Added Support to return WAN MAC for RDKV devices for RDK-40665