### PR TITLE
Fix Devicemac NULL issue in XER5

### DIFF
--- a/src/rdkb/impl.c
+++ b/src/rdkb/impl.c
@@ -52,6 +52,8 @@
 #define DEVICE_MAC                   "Device.DeviceInfo.X_COMCAST-COM_WAN_MAC"
 #elif defined(_WNXL11BWL_PRODUCT_REQ_)
 #define DEVICE_MAC                   "Device.DeviceInfo.X_COMCAST-COM_WAN_MAC"
+#elif defined(_XER5_PRODUCT_REQ_)
+#define DEVICE_MAC                   "Device.DeviceInfo.X_COMCAST-COM_WAN_MAC"
 #else
 #define DEVICE_MAC                   "Device.X_CISCO_COM_CableModem.MACAddress"
 #endif


### PR DESCRIPTION
Fixing DeviceMac NULL Issue in XER5 