### PR TITLE
RDKBACCL-291: Webconfig support

### DIFF
--- a/src/rdkb/impl.c
+++ b/src/rdkb/impl.c
@@ -46,7 +46,7 @@
 #define DEVICE_MAC                   "Device.DPoE.Mac_address"
 #elif defined(PLATFORM_RASPBERRYPI)
 #define DEVICE_MAC                   "Device.Ethernet.Interface.5.MACAddress"
-#elif defined(RDKB_EMU)
+#elif defined(RDKB_EMU) || defined(_PLATFORM_BANANAPI_R4_)
 #define DEVICE_MAC                   "Device.DeviceInfo.X_COMCAST-COM_WAN_MAC"
 #elif defined(_HUB4_PRODUCT_REQ_)
 #define DEVICE_MAC                   "Device.DeviceInfo.X_COMCAST-COM_WAN_MAC"


### PR DESCRIPTION
Reason for change: Defining Device Mac that can be retrived by webconfig.
Test Procedure: Build and test that no error log should be present in WEBCONFIGlog.txt.0 wrt Device_Mac.
Risks: None