### PR TITLE
RDKBDEV-3445, RDKBACCL-1766: Webconfig Support on ARM system Ready

### DIFF
--- a/src/rdkb/impl.c
+++ b/src/rdkb/impl.c
@@ -46,7 +46,7 @@
 #define DEVICE_MAC                   "Device.DPoE.Mac_address"
 #elif defined(PLATFORM_RASPBERRYPI)
 #define DEVICE_MAC                   "Device.Ethernet.Interface.5.MACAddress"
-#elif defined(RDKB_EMU) || defined(_PLATFORM_BANANAPI_R4_)
+#elif defined(RDKB_EMU) || defined(_PLATFORM_BANANAPI_R4_) || defined(_PLATFORM_GENERICARM_)
 #define DEVICE_MAC                   "Device.DeviceInfo.X_COMCAST-COM_WAN_MAC"
 #elif defined(_HUB4_PRODUCT_REQ_)
 #define DEVICE_MAC                   "Device.DeviceInfo.X_COMCAST-COM_WAN_MAC"


### PR DESCRIPTION
Reason for change: Bringing webconfig support in ARM system ready
Test procedure: By default X_RDK_WebConfig.RfcEnable will be enabled state, once device boots up supportedocs will be updated. Update the set changes from webconfig server.
Risks: low